### PR TITLE
Fixed a few warn command bugs:

### DIFF
--- a/manageable.py
+++ b/manageable.py
@@ -1,4 +1,5 @@
 from discord.ext.commands.bot import Bot
+from discord import Intents
 import Code.Cogs.Base as Base
 from Code.Cogs.ModToolsCogs import UserWarnCog
 from Code.Cogs.MessagingCogs import HelpCog, TagCog
@@ -9,7 +10,14 @@ if __name__ == '__main__':
     # Build the bot
     Base.ConfiguredCog.logger.info('Constructing Manageable bot...')
     Base.ConfiguredCog.logger.debug(f'Building bot.')
-    discord_bot = Bot(Base.ConfiguredCog.config['command_prefix'])
+
+    intents = Intents.default()
+    require_member_intent = Base.is_cog_enabled('airlock', Base.ConfiguredCog.config)
+    Base.ConfiguredCog.logger.debug(f'Airlock Cog check resulted in: {require_member_intent} (for privileged intent).')
+    if require_member_intent:
+        intents.members = True
+
+    discord_bot = Bot(Base.ConfiguredCog.config['command_prefix'], intents=intents)
 
     Base.ConfiguredCog.logger.debug('Removing built-in help command.')
     discord_bot.remove_command('help')  # We are providing our own help command

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ Manageable will need these permissions to run. Omitting any of these permissions
 | Embed Links     | The bot needs to be able to embed links to display some commands correctly.     |
 | Add Reactions   | The bot uses reactions to control pagination of its help command.               |
 
+**PLEASE NOTE**: On top of these permissions, the `warn` command _requires_ the `Server Members` privileged intent, so that it can view the full list of members to apply warnings to them as needed. Please make sure this Privileged Intent is enabled on the Discord Developer Dashboard.
+
 ##### 4) Configure the Bot Functionality
 Open `config.json`, located in the `Config` folder. Paste in the bot's token you received from discord in the `token` line, and configure any other information desired. Documentation for the configuration file is found in a later section.
 


### PR DESCRIPTION
1) added Server Members privileged intent so that Manageable can properly view the list of members to look them up for warnings.
2) fixed a bug where the warning deprecation process wasn't properly finding rows to delete, and was breaking when it couldn't find any.
3) fixed a bug with the warning view process where the count was incorrectly set to 1 when there were no database rows that were queried. This appears to be a weird issue with `sqlalchemy.orm.Query` returning a single `NoneType` object when it has no rows.