### PR TITLE
Fixed multi-prepped cookies and tasks not firing

### DIFF
--- a/Code/Cogs/Base.py
+++ b/Code/Cogs/Base.py
@@ -115,7 +115,7 @@ class ConfiguredCog(commands.Cog):
     Methods
     -------
     __init__                Sets up the Cog for general usage.
-    convert_color           A static class method for use processing stringified hex codes into integers.
+    convert_color           A static class method for use processing serialized hex codes into integers.
     find_role_in_guild      Searches for the name of a role in the bot's guild.
     member_contains_role    Checks to see if a given member has a certain role or not.
     """
@@ -135,7 +135,7 @@ class ConfiguredCog(commands.Cog):
 
     @staticmethod
     def convert_color(color_hex_code: str):
-        """A static method used for processing stringified hex codes into integers
+        """A static method used for processing serialized hex codes into integers
 
         Parameters
         ----------
@@ -151,7 +151,7 @@ class ConfiguredCog(commands.Cog):
         if color_hex_code is None or (len(color_hex_code) != 4 and len(color_hex_code) != 7):
             return color_hex_code
 
-        color_hex_code = color_hex_code[1:]  # Crop out the hash tag at the start
+        color_hex_code = color_hex_code[1:]  # Crop out the hashtag at the start
         return int(color_hex_code, 16)
 
     def is_cog_enabled(self, cog_name: str) -> Optional[bool]:

--- a/Code/Cogs/MessagingCogs.py
+++ b/Code/Cogs/MessagingCogs.py
@@ -54,8 +54,6 @@ class TagCog(ConfiguredCog):
 
             # Build tag data
             color = ConfiguredCog.convert_color(self._get_tag_data_safe(tag_data, 'color'))
-            if color is None:
-                color = Embed.Empty
 
             title = self._get_tag_data_safe(tag_data, 'title')
             if title is None:
@@ -87,7 +85,7 @@ class TagCog(ConfiguredCog):
 
         Parameters
         ----------
-        tag_data:   dict    A dictionary of tags an their data, where the keys are strings referencing the tag's
+        tag_data:   dict    A dictionary of tags and their data, where the keys are strings referencing the tag's
                             name, and the values are dictionaries denoting the data to build the tag.
         tag_name:   str     The key to query in the provided data.
 
@@ -251,9 +249,9 @@ class HelpCog(ConfiguredCog):
         # Error catching for invalid commands
         full_command_name = None
         for command in enabled_commands:
-            # note that the "key" is the `command` part of the helptext, which could have parameters described in it
+            # note that the "key" is the `command` part of the help text, which could have parameters described in it
             # like so: `"warn <action> <user>`", so we only need to validate against the first word of the command
-            # for the user's query. If we succeed, jot down the full key so we can use that from now on.
+            # for the user's query. If we succeed, jot down the full key, so we can use that from now on.
             if command_name == command.split()[0]:
                 full_command_name = command
                 break
@@ -272,7 +270,7 @@ class HelpCog(ConfiguredCog):
         for detail in command_data['details']:
             embed.add_field(name=detail['parameter'], value=detail['description'], inline=False)
 
-        # details are not paginated as of yet, so just "pretend" for consistency
+        # details are not paginated yet, so just "pretend" for consistency
         embed.set_footer(text='Page 1/1')
         embed_list.append(embed)
 
@@ -310,8 +308,8 @@ class HelpCog(ConfiguredCog):
 
     def _get_check_method(self, message: Message, allow_decrease: bool, allow_increase: bool) -> callable([..., bool]):
         """Builds and returns a method that can be plugged into a bot's check functionality.
-           The method's allow_decrease and allow_increase variables will be "baked" into the method before its passed to
-           the bot, which will be able to alter the flow of functionality when watching for reacts.
+           The method's allow_decrease and allow_increase variables will be "baked" into the method before it's passed
+           to the bot, which will be able to alter the flow of functionality when watching for reacts.
 
         Parameters
         ----------
@@ -367,9 +365,6 @@ class CookieHuntCog(ConfiguredCog):
         self.cookie_drop_delay_hours = None
         self.cookie_drop_delay_minutes = None
         self.cookie_type = None
-
-        # Start the task
-        self._check_to_send_cookie.start()
 
     @commands.command()
     async def gimme(self, ctx: commands.Context):
@@ -552,12 +547,10 @@ class CookieHuntCog(ConfiguredCog):
             else:
                 self.logger.error('No valid channels were found. Skipping drop.')
 
-    @commands.Cog.listener()
-    async def on_ready(self):
-        """Cog Listener to prep for a cookie drop on start."""
+    def cog_load(self) -> None:
+        """Overridden from commands.Cog; starts the automated task."""
 
-        # Prepare for a drop
-        self._prep_cookie_drop()
+        self._check_to_send_cookie.start()
 
     def cog_unload(self):
         """Overridden from commands.Cog; stops the automated task."""
@@ -662,7 +655,7 @@ class DiceRollerCog(ConfiguredCog):
 
             try:
                 step_data, result = parser.parse(lexer.tokenize(dice))
-            except TypeError as exception:
+            except TypeError:
                 await ctx.send("There was an error with your roll syntax. Please try again.")
                 return
 

--- a/Code/Cogs/ModToolsCogs.py
+++ b/Code/Cogs/ModToolsCogs.py
@@ -278,15 +278,16 @@ class AutoDrawingPrompt(ConfiguredCog):
         super().__init__(bot)
         self.current_prompt = ''
 
-        # Start the task
-        self._get_sketch_prompt.start()
-
     @commands.Cog.listener()
     async def on_ready(self):
         """Cog Listener to automatically run the task on start."""
 
-        # Run the task so that we aren't waiting for the task
         await self._get_sketch_prompt()
+
+    async def cog_load(self) -> None:
+        """Overridden from commands.Cog; starts the automated task."""
+
+        self._get_sketch_prompt.start()
 
     def cog_unload(self):
         """Overridden from commands.Cog; stops the automated task."""
@@ -384,3 +385,5 @@ class AutoDrawingPrompt(ConfiguredCog):
 
                     # Note down that we found today's prompt (so as not to re-send it)
                     self.current_prompt = drawing_prompt
+
+                    break

--- a/manageable.py
+++ b/manageable.py
@@ -8,10 +8,14 @@ from Code.Cogs.SystemInteractionCogs import GlobalErrorHandlingCog, RoleRequestC
 import asyncio
 
 
-async def build_discord_bot() -> Bot:
-    # Build the bot
-    Base.ConfiguredCog.logger.info('Constructing Manageable bot...')
-    Base.ConfiguredCog.logger.debug(f'Building bot.')
+def construct_bot() -> Bot:
+    """Constructs a discord bot with the necessary intents
+
+    Returns
+    -------
+    discord.ext.commands.bot.Bot    An initialized, but empty, discord bot.
+    """
+    Base.ConfiguredCog.logger.debug(f'Initializing bot.')
 
     intents = Intents.default()
     intents.members = True  # Among others, the help command needs the members intent to monitor reactions
@@ -19,9 +23,16 @@ async def build_discord_bot() -> Bot:
 
     discord_bot = Bot(Base.ConfiguredCog.config['command_prefix'], help_command=None, intents=intents)
 
-    # Add the necessary cogs
-    Base.ConfiguredCog.logger.info('Attaching functionality...')
+    return discord_bot
 
+
+async def add_cog_functionality(discord_bot: Bot) -> None:
+    """Adds cogs as needed to the provided bot
+
+    Parameters
+    ----------
+    discord_bot:    discord.ext.commands.bot.Bot    The bot to add Cogs to
+    """
     # Do not disable
     Base.ConfiguredCog.logger.debug('Adding GlobalErrorHandling Cog.')
     await discord_bot.add_cog(GlobalErrorHandlingCog(discord_bot))
@@ -86,13 +97,21 @@ async def build_discord_bot() -> Bot:
     else:
         Base.ConfiguredCog.logger.debug('Skipping DiceRoller Cog.')
 
-    return discord_bot
+
+async def main() -> None:
+    """Main entry point of the Manageable system. Should be called only when executing the software."""
+
+    Base.ConfiguredCog.logger.info('Constructing Manageable bot...')
+    bot = construct_bot()
+
+    async with bot:
+        Base.ConfiguredCog.logger.info('Attaching functionality...')
+        await add_cog_functionality(bot)
+
+        # Run the bot
+        Base.ConfiguredCog.logger.warning('Launching Manageable with the specified bot token.')
+        await bot.start(Base.ConfiguredCog.config['token'])
 
 
 if __name__ == '__main__':
-    # Build the bot
-    bot = asyncio.run(build_discord_bot())
-
-    # Run the bot
-    Base.ConfiguredCog.logger.warning('Launching Manageable with the specified bot token.')
-    bot.run(Base.ConfiguredCog.config['token'])
+    asyncio.run(main())


### PR DESCRIPTION
Fixed tasks not firing post-upgrade. The tasks were being started outside the main event loop, which was causing their async binding to not carry over when the bot event loop fired.

Also fixed an issue with some tasks occasionally firing twice. discord's `on_ready()` call can fire multiple times unexpectedly, thus causing cookies to prep multiple times.

Also fixed a few typos & linter issues found around the codebase.